### PR TITLE
R9 mx connections

### DIFF
--- a/docs/FRSKY_R9.md
+++ b/docs/FRSKY_R9.md
@@ -44,8 +44,8 @@ The wiring is similar to the ExpressLRS docs found in the link below. Different 
 | Pin 2 VIN | Power 3.5-10V
 | Pin 5 SBUS OUT | RC Output
 | CH1 | Debug Tx
-| CH2 | Serial Rx
-| CH3 | Serial Tx
+| CH2 | Serial Tx
+| CH3 | Serial Rx
 | CH4 | Buzzer
 
 

--- a/docs/FRSKY_R9.md
+++ b/docs/FRSKY_R9.md
@@ -43,10 +43,10 @@ The wiring is similar to the ExpressLRS docs found in the link below. Different 
 | Pin 1 GND | Ground
 | Pin 2 VIN | Power 3.5-10V
 | Pin 5 SBUS OUT | RC Output
-| CH1 | Debug Tx
+| CH1 | Buzzer
 | CH2 | Serial Tx
 | CH3 | Serial Rx
-| CH4 | Buzzer
+| CH4 | Debug Tx
 
 
 ### As Tx Module ###


### PR DESCRIPTION
I had reason to use the Rx buzzer today and found that the Debug Tx and Buzzer were also reversed.  :-(
I guess the order of the pads was completely reversed in the code comments I took this info from?