### PR TITLE
CRSF sensor page added

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Documentation for the [mLRS project](https://github.com/olliw42/mLRS).
 
 ### Setups ###
 - Setup for [CRSF Telemetry and Yaapu Telemetry App](docs/CRSF.md)
+    - [CRSF Sensors](docs/CRSF_SENSORS.md)
 - Setup for [MAVLink for OpenTx](docs/MAVLINK_FOR_OPENTX.md)
 - Basic setup for [SBus Radios](docs/BASIC_SETUP.md)
 

--- a/docs/CRSF.md
+++ b/docs/CRSF.md
@@ -82,7 +82,7 @@ Notes:
 
 The external RF module needs to be set up for CRSF protocol with 400K baud rate. In EdgeTX/OpenTX, this is done in MDL->MODEL SETUP.
 
-In EdgeTX/OpenTX go to MDL->TELEMETRY and select "Discover new sensors". You should see sensors appearing; mLRS currently supports 28 sensors. ([CRSF Sensors](docs/CRSF_SENSORS.md))
+In EdgeTX/OpenTX go to MDL->TELEMETRY and select "Discover new sensors". You should see sensors appearing; mLRS currently provides 28 sensors. ([CRSF Sensors](docs/CRSF_SENSORS.md))
 
 Install the Yaapu app exactly as described in its wiki. Note: You need to install the dev version, the stable release version will not work. You need to enable the CRSF support: Start the "Yaapu Config" script in SYS->TOOLS, and set "enable CRSF support: yes" (then repower the radio). You can check if all is good by running the "Yaapu Debug CRSF" script in SYS->TOOLS.
 

--- a/docs/CRSF.md
+++ b/docs/CRSF.md
@@ -82,7 +82,7 @@ Notes:
 
 The external RF module needs to be set up for CRSF protocol with 400K baud rate. In EdgeTX/OpenTX, this is done in MDL->MODEL SETUP.
 
-In EdgeTX/OpenTX go to MDL->TELEMETRY and select "Discover new sensors". You should see sensors appearing; mLRS currently supports 27 sensors.
+In EdgeTX/OpenTX go to MDL->TELEMETRY and select "Discover new sensors". You should see sensors appearing; mLRS currently supports 28 sensors. ([CRSF Sensors](docs/CRSF_SENSORS.md))
 
 Install the Yaapu app exactly as described in its wiki. Note: You need to install the dev version, the stable release version will not work. You need to enable the CRSF support: Start the "Yaapu Config" script in SYS->TOOLS, and set "enable CRSF support: yes" (then repower the radio). You can check if all is good by running the "Yaapu Debug CRSF" script in SYS->TOOLS.
 

--- a/docs/CRSF_SENSORS.md
+++ b/docs/CRSF_SENSORS.md
@@ -6,35 +6,36 @@
 
 mLRS provides the following telemetry sensors when using CRSF:
 
-Num | Datapoint | Description                                                              | Data Source |
---- | --------- | ------------------------------------------------------------------------ | ----------- |
-1   | 1RSS       | Receiver RSSI                                                           | mLRS        |
-2   | 2RSS       | Not supported                                                           |             |
-3   | Alt        | Altitude                                                                | FC          |
-4   | ANT        | Not supported                                                           |             |
-5   | Bat%       | Battery percent remaining                                               | FC          |
-6   | Capa       | Current consumption                                                     | FC          |
-7   | Curr       | Current draw                                                            | FC          |
-8   | FM         | Flight mode                                                             | FC          |
-9   | GPS        | GPS coordinates                                                         | FC          |
-10  | GSpd       | Ground speed                                                            | FC          |
-11  | Hdg        | Heading                                                                 | FC          |
-12  | Ptch       | FC pitch angle                                                          | FC          |
-13  | RFMD       | Receiver update rate (19, 31, 50)                                       | mLRS        |
-14  | Roll       | FC roll angle                                                           | FC          |
-15  | RQly       | Receiver link quality                                                   | mLRS        |
-16  | RRSP       | Receiver RSSI percentage                                                | mLRS        |
-17  | RSNR       | Not supported                                                           |             |
-18  | RxBt       | Battery Voltage                                                         | FC          |
-19  | Sats       | GPS satellites acquired                                                 | FC          |
-20  | TFPS       | Transmitter update rate (20, 30, 50 - use RFMD instead)                 | mLRS        |
-21  | TPWR       | Transmitter power                                                       | mLRS        |
-22  | TPw2*      | Transmitter power                                                       | mLRS        |
-23  | TQly       | Tramsmitter link quality                                                | mLRS        |
-24  | TRSP       | Transmitter RSSI percentage                                             | mLRS        |
-25  | TRSS       | Transmitter RSSI                                                        | mLRS        |
-26  | TSNR       | Transmitter signal to noise ratio                                       | mLRS        |
-27  | VSpd       | Vertical speed (barometer)                                              | FC          |
-28  | Yaw        | FC yaw angle                                                            | FC          |
+Num | Datapoint   | Description                                                             | Data Source |
+--- | ----------- | ----------------------------------------------------------------------- | ----------- |
+1   | 1RSS*       | Receiver RSSI                                                           | mLRS        |
+2   | 2RSS        | Not supported                                                           |             |
+3   | Alt         | Altitude                                                                | FC          |
+4   | ANT         | Active receiver antenna                                                 | mLRS        |
+5   | Bat%        | Battery percent remaining                                               | FC          |
+6   | Capa        | Current consumption                                                     | FC          |
+7   | Curr        | Current draw                                                            | FC          |
+8   | FM          | Flight mode                                                             | FC          |
+9   | GPS         | GPS coordinates                                                         | FC          |
+10  | GSpd        | Ground speed                                                            | FC          |
+11  | Hdg         | Heading                                                                 | FC          |
+12  | Ptch        | FC pitch angle                                                          | FC          |
+13  | RFMD        | Receiver update rate (19, 31, 1 - 50Hz)                                 | mLRS        |
+14  | Roll        | FC roll angle                                                           | FC          |
+15  | RQly        | Receiver link quality                                                   | mLRS        |
+16  | RRSP        | Receiver RSSI percentage                                                | mLRS        |
+17  | RSNR        | Not supported                                                           |             |
+18  | RxBt        | Battery Voltage                                                         | FC          |
+19  | Sats        | GPS satellites acquired                                                 | FC          |
+20  | TFPS        | Transmitter update rate (20, 30, 50)                                    | mLRS        |
+21  | TPWR        | Transmitter power (mW)                                                  | mLRS        |
+22  | TPw2**      | Transmitter power (CRSF power level)                                    | mLRS        |
+23  | TQly        | Tramsmitter link quality                                                | mLRS        |
+24  | TRSP        | Transmitter RSSI percentage                                             | mLRS        |
+25  | TRSS*       | Transmitter RSSI                                                        | mLRS        |
+26  | TSNR        | Transmitter signal to noise ratio                                       | mLRS        |
+27  | VSpd        | Vertical speed (barometer)                                              | FC          |
+28  | Yaw         | FC yaw angle                                                            | FC          |
 
-\*Shows up as a 2nd 'TPWR' on EdgeTX
+\*RSSI values are displayed as positive values, e.g. -85dBm is displayed as 85dBm  
+\**Shows up as a 2nd 'TPWR' on EdgeTX

--- a/docs/CRSF_SENSORS.md
+++ b/docs/CRSF_SENSORS.md
@@ -1,0 +1,38 @@
+# mLRS Documentation: CRSF Sensors #
+
+([back to main page](../README.md))
+
+([back to CRSF page](CRSF.md))
+
+mLRS supports the following telemetry sensors when using CRSF:
+
+Num | Datapoint | Description                                 | Data Source |
+--- | --------- | ------------------------------------------- | ----------- |
+1   | 1RSS      | Receiver RSSI of antenna 1                  | mLRS        |
+2   | 2RSS      | Receiver RSSI of antenna 2 (not supported)  | mLRS        |
+3   | Alt       | Altitude                                    | FC          |
+4   | ANT       | Receiver antenna in-use?                    | mLRS        |
+5   | Bat%      | Battery percent remaining                   | FC          |
+6   | Capa      | Current consumption                         | FC          |
+7   | Curr      | Current draw                                | FC          |
+8   | FM        | Flight mode                                 | FC          |
+9   | GPS       | GPS coordinates                             | FC          |
+10  | GSpd      | Ground speed                                | FC          |
+11  | Hdg       | Heading                                     | FC          |
+12  | Ptch      | FC pitch angle                              | FC          |
+13  | RFMD      | Receiver update rate                        | mLRS        |
+14  | Roll      | FC roll angle                               | FC          |
+15  | RQly      | Receiver link quality                       | mLRS        |
+16  | RRSP      | Receiver RSSI percentage                    | mLRS        |
+17  | RSNR      | Receiver signal to noise ratio              | mLRS        |
+18  | RxBt      | Battery Voltage                             | FC          |
+19  | Sats      | GPS satellites acquired                     | FC          |
+20  | TFPS      | Transmitter update rate                     | mLRS        |
+21  | TPWR      | Transmitter power                           | mLRS        |
+22  | TPWR      | Transmitter power                           | mLRS        |
+23  | TQly      | Tramsmitter link quality                    | mLRS        |
+24  | TRSP      | Transmitter RSSI percentage                 | mLRS        |
+25  | TRSS      | Transmitter RSSI                            | mLRS        |
+26  | TSNR      | Transmitter signal to noise ratio           | mLRS        |
+27  | VSpd      | Vertical speed (barometer)                  | FC          |
+28  | Yaw       | FC yaw angle                                | FC          |

--- a/docs/CRSF_SENSORS.md
+++ b/docs/CRSF_SENSORS.md
@@ -4,35 +4,37 @@
 
 ([back to CRSF page](CRSF.md))
 
-mLRS supports the following telemetry sensors when using CRSF:
+mLRS provides the following telemetry sensors when using CRSF:
 
-Num | Datapoint | Description                                 | Data Source |
---- | --------- | ------------------------------------------- | ----------- |
-1   | 1RSS      | Receiver RSSI of antenna 1                  | mLRS        |
-2   | 2RSS      | Receiver RSSI of antenna 2 (not supported)  | mLRS        |
-3   | Alt       | Altitude                                    | FC          |
-4   | ANT       | Receiver antenna in-use?                    | mLRS        |
-5   | Bat%      | Battery percent remaining                   | FC          |
-6   | Capa      | Current consumption                         | FC          |
-7   | Curr      | Current draw                                | FC          |
-8   | FM        | Flight mode                                 | FC          |
-9   | GPS       | GPS coordinates                             | FC          |
-10  | GSpd      | Ground speed                                | FC          |
-11  | Hdg       | Heading                                     | FC          |
-12  | Ptch      | FC pitch angle                              | FC          |
-13  | RFMD      | Receiver update rate                        | mLRS        |
-14  | Roll      | FC roll angle                               | FC          |
-15  | RQly      | Receiver link quality                       | mLRS        |
-16  | RRSP      | Receiver RSSI percentage                    | mLRS        |
-17  | RSNR      | Receiver signal to noise ratio              | mLRS        |
-18  | RxBt      | Battery Voltage                             | FC          |
-19  | Sats      | GPS satellites acquired                     | FC          |
-20  | TFPS      | Transmitter update rate                     | mLRS        |
-21  | TPWR      | Transmitter power                           | mLRS        |
-22  | TPWR      | Transmitter power                           | mLRS        |
-23  | TQly      | Tramsmitter link quality                    | mLRS        |
-24  | TRSP      | Transmitter RSSI percentage                 | mLRS        |
-25  | TRSS      | Transmitter RSSI                            | mLRS        |
-26  | TSNR      | Transmitter signal to noise ratio           | mLRS        |
-27  | VSpd      | Vertical speed (barometer)                  | FC          |
-28  | Yaw       | FC yaw angle                                | FC          |
+Num | Datapoint | Description                                                              | Data Source |
+--- | --------- | ------------------------------------------------------------------------ | ----------- |
+1   | 1RSS       | Receiver RSSI                                                           | mLRS        |
+2   | 2RSS       | Not supported                                                           |             |
+3   | Alt        | Altitude                                                                | FC          |
+4   | ANT        | Not supported                                                           |             |
+5   | Bat%       | Battery percent remaining                                               | FC          |
+6   | Capa       | Current consumption                                                     | FC          |
+7   | Curr       | Current draw                                                            | FC          |
+8   | FM         | Flight mode                                                             | FC          |
+9   | GPS        | GPS coordinates                                                         | FC          |
+10  | GSpd       | Ground speed                                                            | FC          |
+11  | Hdg        | Heading                                                                 | FC          |
+12  | Ptch       | FC pitch angle                                                          | FC          |
+13  | RFMD       | Receiver update rate (19, 31, 50)                                       | mLRS        |
+14  | Roll       | FC roll angle                                                           | FC          |
+15  | RQly       | Receiver link quality                                                   | mLRS        |
+16  | RRSP       | Receiver RSSI percentage                                                | mLRS        |
+17  | RSNR       | Not supported                                                           |             |
+18  | RxBt       | Battery Voltage                                                         | FC          |
+19  | Sats       | GPS satellites acquired                                                 | FC          |
+20  | TFPS       | Transmitter update rate (20, 30, 50 - use RFMD instead)                 | mLRS        |
+21  | TPWR       | Transmitter power                                                       | mLRS        |
+22  | TPw2*      | Transmitter power                                                       | mLRS        |
+23  | TQly       | Tramsmitter link quality                                                | mLRS        |
+24  | TRSP       | Transmitter RSSI percentage                                             | mLRS        |
+25  | TRSS       | Transmitter RSSI                                                        | mLRS        |
+26  | TSNR       | Transmitter signal to noise ratio                                       | mLRS        |
+27  | VSpd       | Vertical speed (barometer)                                              | FC          |
+28  | Yaw        | FC yaw angle                                                            | FC          |
+
+\*Shows up as a 2nd 'TPWR' on EdgeTX

--- a/docs/CRSF_SENSORS.md
+++ b/docs/CRSF_SENSORS.md
@@ -34,7 +34,7 @@ Num | Datapoint   | Description                                                 
 24  | TRSP        | Transmitter RSSI percentage                                             | mLRS        |
 25  | TRSS*       | Transmitter RSSI                                                        | mLRS        |
 26  | TSNR        | Transmitter signal to noise ratio                                       | mLRS        |
-27  | VSpd        | Vertical speed (barometer)                                              | FC          |
+27  | VSpd        | Vertical speed                                                          | FC          |
 28  | Yaw         | FC yaw angle                                                            | FC          |
 
 \*RSSI values are displayed as positive values, e.g. -85dBm is displayed as 85dBm  


### PR DESCRIPTION
New page with CRSF sensors.

Notes:
- There are 2 'TPWR' datapoints, verified on two transmitters.
- Not sure on 'ANT' datapoint