### PR TITLE
E77-MBL, WioE5, R9 boards: add info on frequency range and output power

### DIFF
--- a/docs/EBYTE_E77_MBL.md
+++ b/docs/EBYTE_E77_MBL.md
@@ -4,6 +4,9 @@
 
 EBYTE E77 MBL Boards are an option for building mLRS equipment. These boards use the EBYTE E77 module and are available in both 868/915 MHz and 433 MHz/70 cm versions. However, these boards are not perfect since their pins are not ready-made for the purposes of mLRS. So, some tweaking and (easy) soldering is required.
 
+Frequency Bands: 868 MHz/915 MHz or 433 MHz/70 cm (depending on module) 
+max. RF Output Power: 22 dBm (158 mW)
+
 **Important: If you are planning to use the SMA connector for the antenna, ensure that a 0 Ohm resistor is populated. Multiple users have reported that it is not present on their modules. Refer to the red square next to the SMA connector in the diagrams below for the location.**
 
 ## EBYTE E77 MBL Boards ##

--- a/docs/EBYTE_E77_MBL.md
+++ b/docs/EBYTE_E77_MBL.md
@@ -4,9 +4,22 @@
 
 EBYTE E77 MBL Boards are an option for building mLRS equipment. These boards use the EBYTE E77 module and are available in both 868/915 MHz and 433 MHz/70 cm versions. However, these boards are not perfect since their pins are not ready-made for the purposes of mLRS. So, some tweaking and (easy) soldering is required.
 
-Frequency Bands: 868 MHz/915 MHz or 433 MHz/70 cm (depending on module) <br>
-max. RF Output Power: 22 dBm (158 mW) <br>
-Weight: 9.35 grams without antenna
+<table>
+  <tbody>
+    <tr>
+      <td>Frequency Bands</td>
+      <td>868 MHz/915 MHz (E77-900MBL-01) or 433 MHz/70 cm (E77-400MBL-01)</td>
+    </tr>
+    <tr>
+      <td>max. RF Output Power</td>
+      <td>22 dBm (158 mW)</td>
+    </tr>
+    <tr>
+      <td>Weight</td>
+      <td>9.35 grams without antenna</td>
+    </tr>
+  </tbody>
+</table>
 
 **Important: If you are planning to use the SMA connector for the antenna, ensure that a 0 Ohm resistor is populated. Multiple users have reported that it is not present on their modules. Refer to the red square next to the SMA connector in the diagrams below for the location.**
 

--- a/docs/EBYTE_E77_MBL.md
+++ b/docs/EBYTE_E77_MBL.md
@@ -5,6 +5,7 @@
 EBYTE E77 MBL Boards are an option for building mLRS equipment. These boards use the EBYTE E77 module and are available in both 868/915 MHz and 433 MHz/70 cm versions. However, these boards are not perfect since their pins are not ready-made for the purposes of mLRS. So, some tweaking and (easy) soldering is required.
 
 Frequency Bands: 868 MHz/915 MHz or 433 MHz/70 cm (depending on module) 
+
 max. RF Output Power: 22 dBm (158 mW)
 
 **Important: If you are planning to use the SMA connector for the antenna, ensure that a 0 Ohm resistor is populated. Multiple users have reported that it is not present on their modules. Refer to the red square next to the SMA connector in the diagrams below for the location.**

--- a/docs/EBYTE_E77_MBL.md
+++ b/docs/EBYTE_E77_MBL.md
@@ -4,9 +4,9 @@
 
 EBYTE E77 MBL Boards are an option for building mLRS equipment. These boards use the EBYTE E77 module and are available in both 868/915 MHz and 433 MHz/70 cm versions. However, these boards are not perfect since their pins are not ready-made for the purposes of mLRS. So, some tweaking and (easy) soldering is required.
 
-Frequency Bands: 868 MHz/915 MHz or 433 MHz/70 cm (depending on module) 
-
-max. RF Output Power: 22 dBm (158 mW)
+Frequency Bands: 868 MHz/915 MHz or 433 MHz/70 cm (depending on module) <br>
+max. RF Output Power: 22 dBm (158 mW) <br>
+Weight: 9.35 grams without antenna
 
 **Important: If you are planning to use the SMA connector for the antenna, ensure that a 0 Ohm resistor is populated. Multiple users have reported that it is not present on their modules. Refer to the red square next to the SMA connector in the diagrams below for the location.**
 

--- a/docs/FRSKY_R9.md
+++ b/docs/FRSKY_R9.md
@@ -7,6 +7,7 @@ The Frsky R9M transmitter module and R9MX receiver are commercially available an
 Comment: mLRS also supports the R9MM receiver. However, flashing the R9MM with ST-Link is really tedious and requires top soldering skills or employing other tricks, as one needs to connect to four tiny solder pads. You really should consider using the R9MX receiver instead.
 
 Frequency Bands: 868 MHz or 915 MHz (depending on the model)
+
 max. RF Output Power: 30 dBm (1 W) for R9M, and 17 dBm (50 mW) for R9MM, R9MX
 
 

--- a/docs/FRSKY_R9.md
+++ b/docs/FRSKY_R9.md
@@ -6,10 +6,8 @@ The Frsky R9M transmitter module and R9MX receiver are commercially available an
 
 Comment: mLRS also supports the R9MM receiver. However, flashing the R9MM with ST-Link is really tedious and requires top soldering skills or employing other tricks, as one needs to connect to four tiny solder pads. You really should consider using the R9MX receiver instead.
 
-Frequency Bands: 868 MHz or 915 MHz (depending on the model)
-
+Frequency Bands: 868 MHz or 915 MHz (depending on the model) <br>
 max. RF Output Power: 30 dBm (1 W) for R9M, and 17 dBm (50 mW) for R9MM, R9MX
-
 
 ## R9M Tx Module ##
 

--- a/docs/FRSKY_R9.md
+++ b/docs/FRSKY_R9.md
@@ -10,7 +10,7 @@ Comment: mLRS also supports the R9MM receiver. However, flashing the R9MM with S
   <tbody>
     <tr>
       <td>Frequency Bands</td>
-      <td>868 MHz/915 MHz (depending on the model)</td>
+      <td>868 MHz/915 MHz</td>
     </tr>
     <tr>
       <td>max. RF Output Power</td>

--- a/docs/FRSKY_R9.md
+++ b/docs/FRSKY_R9.md
@@ -6,6 +6,9 @@ The Frsky R9M transmitter module and R9MX receiver are commercially available an
 
 Comment: mLRS also supports the R9MM receiver. However, flashing the R9MM with ST-Link is really tedious and requires top soldering skills or employing other tricks, as one needs to connect to four tiny solder pads. You really should consider using the R9MX receiver instead.
 
+Frequency Bands: 868 MHz or 915 MHz (depending on the model)
+max. RF Output Power: 30 dBm (1 W) for R9M, and 17 dBm (50 mW) for R9MM, R9MX
+
 
 ## R9M Tx Module ##
 

--- a/docs/FRSKY_R9.md
+++ b/docs/FRSKY_R9.md
@@ -6,8 +6,18 @@ The Frsky R9M transmitter module and R9MX receiver are commercially available an
 
 Comment: mLRS also supports the R9MM receiver. However, flashing the R9MM with ST-Link is really tedious and requires top soldering skills or employing other tricks, as one needs to connect to four tiny solder pads. You really should consider using the R9MX receiver instead.
 
-Frequency Bands: 868 MHz or 915 MHz (depending on the model) <br>
-max. RF Output Power: 30 dBm (1 W) for R9M, and 17 dBm (50 mW) for R9MM, R9MX
+<table>
+  <tbody>
+    <tr>
+      <td>Frequency Bands</td>
+      <td>868 MHz/915 MHz (depending on the model)</td>
+    </tr>
+    <tr>
+      <td>max. RF Output Power</td>
+      <td>30 dBm (1 W) for R9M, and 17 dBm (50 mW) for R9MM, R9MX</td>
+    </tr>
+  </tbody>
+</table>
 
 ## R9M Tx Module ##
 

--- a/docs/SEEEDSTUDIO_WIO_E5.md
+++ b/docs/SEEEDSTUDIO_WIO_E5.md
@@ -4,8 +4,18 @@
 
 The SeeedStudio [Wio-E5 module](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC_Module) is a highly attractive module for building mLRS equipment. SeeedStudio provides a number of boards which are based on this module, and which are quite interesting hardware for mLRS. However, these boards are not perfect since their pins are not ready-made for the purposes of mLRS. So, some tweaking and (easy) soldering is required.
 
-Frequency Bands: 868 MHz/915 MHz <br>
-max. RF Output Power: 22 dBm (158 mW)
+<table>
+  <tbody>
+    <tr>
+      <td>Frequency Bands</td>
+      <td>868 MHz/915 MHz</td>
+    </tr>
+    <tr>
+      <td>max. RF Output Power</td>
+      <td>22 dBm (158 mW)</td>
+    </tr>
+  </tbody>
+</table>
 
 ## SeeedStudio Wio-E5 mini dev Board ##
 

--- a/docs/SEEEDSTUDIO_WIO_E5.md
+++ b/docs/SEEEDSTUDIO_WIO_E5.md
@@ -14,6 +14,10 @@ The SeeedStudio [Wio-E5 module](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC
       <td>max. RF Output Power</td>
       <td>22 dBm (158 mW)</td>
     </tr>
+      <tr>
+      <td>Weight</td>
+      <td>E5 Mini: ~8 grams without antenna</td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/SEEEDSTUDIO_WIO_E5.md
+++ b/docs/SEEEDSTUDIO_WIO_E5.md
@@ -4,6 +4,9 @@
 
 The SeeedStudio [Wio-E5 module](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC_Module) is a highly attractive module for building mLRS equipment. SeeedStudio provides a number of boards which are based on this module, and which are quite interesting hardware for mLRS. However, these boards are not perfect since their pins are not ready-made for the purposes of mLRS. So, some tweaking and (easy) soldering is required.
 
+Frequency Bands: 868 MHz/915 MHz
+max. RF Output Power: 22 dBm (158 mW)
+
 ## SeeedStudio Wio-E5 mini dev Board ##
 
 https://wiki.seeedstudio.com/LoRa_E5_mini/

--- a/docs/SEEEDSTUDIO_WIO_E5.md
+++ b/docs/SEEEDSTUDIO_WIO_E5.md
@@ -5,6 +5,7 @@
 The SeeedStudio [Wio-E5 module](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC_Module) is a highly attractive module for building mLRS equipment. SeeedStudio provides a number of boards which are based on this module, and which are quite interesting hardware for mLRS. However, these boards are not perfect since their pins are not ready-made for the purposes of mLRS. So, some tweaking and (easy) soldering is required.
 
 Frequency Bands: 868 MHz/915 MHz
+
 max. RF Output Power: 22 dBm (158 mW)
 
 ## SeeedStudio Wio-E5 mini dev Board ##

--- a/docs/SEEEDSTUDIO_WIO_E5.md
+++ b/docs/SEEEDSTUDIO_WIO_E5.md
@@ -4,8 +4,7 @@
 
 The SeeedStudio [Wio-E5 module](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC_Module) is a highly attractive module for building mLRS equipment. SeeedStudio provides a number of boards which are based on this module, and which are quite interesting hardware for mLRS. However, these boards are not perfect since their pins are not ready-made for the purposes of mLRS. So, some tweaking and (easy) soldering is required.
 
-Frequency Bands: 868 MHz/915 MHz
-
+Frequency Bands: 868 MHz/915 MHz <br>
 max. RF Output Power: 22 dBm (158 mW)
 
 ## SeeedStudio Wio-E5 mini dev Board ##

--- a/docs/SEEEDSTUDIO_WIO_E5.md
+++ b/docs/SEEEDSTUDIO_WIO_E5.md
@@ -16,12 +16,12 @@ The SeeedStudio [Wio-E5 module](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC
     </tr>
       <tr>
       <td>Weight</td>
-      <td>E5 Mini: ~8 grams without antenna</td>
+      <td>Wio-E5 Mini: ~8 grams without antenna</td>
     </tr>
   </tbody>
 </table>
 
-## SeeedStudio Wio-E5 mini dev Board ##
+## SeeedStudio Wio-E5 Mini dev Board ##
 
 https://wiki.seeedstudio.com/LoRa_E5_mini/
 


### PR DESCRIPTION
adds info on supported RF band and max RF output power to three boards/systems.

might be useful info.