### PR TITLE
esp, elrs: don't work with sx126x gear

### DIFF
--- a/docs/ELRS_RECEIVERS.md
+++ b/docs/ELRS_RECEIVERS.md
@@ -4,7 +4,7 @@
 
 ## Supported ELRS Receivers ##
 
-As of April 2024, ELRS receivers with an ESP8285 MCU are experimentally supported by mLRS. The following targets are supported:
+As of April 2024, ELRS receivers with an ESP8285 MCU are supported by mLRS. The following targets are supported:
 
 - Generic 900
 - Generic 900 PA
@@ -15,9 +15,11 @@ To determine if your receiver hardware is supported, go to [ELRS Targets](https:
 
 Note: ELRS receivers that use an ESP32 MCU are under active development.
 
+Note that 900 MHz ELRS receivers cannot connect with mLRS boards which support 868/915 MHz and use the SX126x LoRa chipset. This is because the 900 MHz ELRS gear uses the SX127x LoRa chipset, which is incompatible with the SX126x LoRa chipset for the SF6 spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the SF5 spreading factor which is used for the mLRS 31 Hz mode.
+
 ## Selected ELRS Receivers ##
 
-The following receivers are good choices. They support >= 100 mW, are affordable, and have been validated by the mLRS team.
+The following receivers are good choices. They support &#8805; 100 mW, are affordable, and have been validated by the mLRS team.
 
 <table>
   <tbody>

--- a/docs/ELRS_RECEIVERS.md
+++ b/docs/ELRS_RECEIVERS.md
@@ -15,7 +15,7 @@ To determine if your receiver hardware is supported, go to [ELRS Targets](https:
 
 Note: ELRS receivers that use an ESP32 MCU are under active development.
 
-Note that 900 MHz ELRS receivers cannot connect with mLRS boards which support 868/915 MHz and use the SX126x LoRa chipset. This is because the 900 MHz ELRS gear uses the SX127x LoRa chipset, which is incompatible with the SX126x LoRa chipset for the SF6 spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the SF5 spreading factor which is used for the mLRS 31 Hz mode.
+Note that 868/915 MHz ELRS receivers cannot connect with 868/915 MHz mLRS Tx modules using the SX126x LoRa chipset. This is because the 868/915 MHz ELRS receivers use the SX127x LoRa chipset, which is incompatible with the SX126x LoRa chipset for the SF6 spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the SF5 spreading factor which is used for the mLRS 31 Hz mode.
 
 ## Selected ELRS Receivers ##
 


### PR DESCRIPTION
- mentions incompatibilit with sx126x gear
- removes "experimentally". Now it's in main we should stand to it :) It's pre-relase status anyway
- replaces >=

see https://discord.com/channels/1005096100572700794/1207291418297634827/1227741459931988032