### PR TITLE
elrs receiver, speedybee better seo

### DIFF
--- a/docs/ELRS_RECEIVERS.md
+++ b/docs/ELRS_RECEIVERS.md
@@ -32,7 +32,7 @@ The following receivers are good choices. They support >= 100 mW, are affordable
       <td>27 dBm (500 mw)</td>
     </tr>
     <tr>
-      <td>SpeedyBee Nano</td>
+      <td>SpeedyBee Nano 2.4G</td>
       <td>2.4 GHz</td>
       <td>20 dBm (100 mw)</td>
     </tr>


### PR DESCRIPTION
stupid me
realized that just "speedybee nano" doesn't yield good search results, "speedybee nano 2.4g" is much better ;)