### PR TITLE
Compatibility Note

### DIFF
--- a/docs/E77_EASYSOLDER.md
+++ b/docs/E77_EASYSOLDER.md
@@ -2,8 +2,6 @@
 
 ([back to main page](../README.md))
 
-Note: 868/915 MHz E77 hardware cannot connect with 868/915 MHz mLRS hardware using the SX127x LoRa chipset (ELRS, R9). This is because the 868/915 MHz E77 hardware uses the SX126x LoRa chipset, which is incompatible with the SX127x LoRa chipset for the spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the spreading factor which is used for the mLRS 31 Hz mode.
-
 The E77 Easy Solder Boards are designed to allow one with minimal soldering skills to build their own mLRS hardware. All of the parts except for the E77 module are through-hole parts to aid in assembly. These boards are flexible in that they can be used as a Tx module, receiver or a SiK replacement. Additionally, these boards support diversity when paired with an additional E22 module.
 
 <table>
@@ -19,6 +17,14 @@ The E77 Easy Solder Boards are designed to allow one with minimal soldering skil
     <tr>
       <td>Supported Modes</td>
       <td>31 Hz, 19 Hz</td>
+    </tr>
+    <tr>
+      <td>LoRa Chipset</td>
+      <td>SX126x</td>
+    </tr>
+      <tr>
+      <td>Compatibility</td>
+      <td>Compatible with SeeedStudio Wio-E5, EBYTE E77 MBL.  Incompatible with SX127x hardware (Frsky R9 and ELRS).</td>
     </tr>
   </tbody>
 </table>

--- a/docs/E77_EASYSOLDER.md
+++ b/docs/E77_EASYSOLDER.md
@@ -2,6 +2,8 @@
 
 ([back to main page](../README.md))
 
+Note: 868/915 MHz E77 hardware cannot connect with 868/915 MHz mLRS hardware using the SX127x LoRa chipset (ELRS, R9). This is because the 868/915 MHz E77 hardware uses the SX126x LoRa chipset, which is incompatible with the SX127x LoRa chipset for the spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the spreading factor which is used for the mLRS 31 Hz mode.
+
 The E77 Easy Solder Boards are designed to allow one with minimal soldering skills to build their own mLRS hardware. All of the parts except for the E77 module are through-hole parts to aid in assembly. These boards are flexible in that they can be used as a Tx module, receiver or a SiK replacement. Additionally, these boards support diversity when paired with an additional E22 module.
 
 <table>

--- a/docs/EBYTE_E77_MBL.md
+++ b/docs/EBYTE_E77_MBL.md
@@ -23,6 +23,14 @@ EBYTE E77 MBL Boards are an option for building mLRS equipment. These boards use
       <td>31 Hz, 19 Hz</td>
     </tr>
     <tr>
+      <td>LoRa Chipset</td>
+      <td>SX126x</td>
+    </tr>
+      <tr>
+      <td>Compatibility</td>
+      <td>Compatible with SeeedStudio Wio-E5, E77 Easy Solder.  Incompatible with SX127x hardware (Frsky R9 and ELRS).</td>
+    </tr>
+    <tr>
       <td>Weight</td>
       <td>9.35 grams without antenna</td>
     </tr>

--- a/docs/EBYTE_E77_MBL.md
+++ b/docs/EBYTE_E77_MBL.md
@@ -2,6 +2,8 @@
 
 ([back to main page](../README.md))
 
+Note: 868/915 MHz E77 hardware cannot connect with 868/915 MHz mLRS hardware using the SX127x LoRa chipset (ELRS, R9). This is because the 868/915 MHz E77 hardware uses the SX126x LoRa chipset, which is incompatible with the SX127x LoRa chipset for the spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the spreading factor which is used for the mLRS 31 Hz mode.
+
 EBYTE E77 MBL Boards are an option for building mLRS equipment. These boards use the EBYTE E77 module and are available in both 868/915 MHz and 433 MHz/70 cm versions. However, these boards are not perfect since their pins are not ready-made for the purposes of mLRS. So, some tweaking and (easy) soldering is required.
 
 **Important: If you are planning to use the SMA connector for the antenna, ensure that a 0 Ohm resistor is populated. Multiple users have reported that it is not present on their modules. Refer to the red square next to the SMA connector in the diagrams below for the location.**

--- a/docs/ELRS_RECEIVERS.md
+++ b/docs/ELRS_RECEIVERS.md
@@ -2,7 +2,7 @@
 
 ([back to main page](../README.md))
 
-Note: 868/915 MHz ELRS receivers cannot connect with 868/915 MHz mLRS Tx modules using the SX126x LoRa chipset. This is because the 868/915 MHz ELRS receivers use the SX127x LoRa chipset, which is incompatible with the SX126x LoRa chipset for the spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the spreading factor which is used for the mLRS 31 Hz mode.
+Note: 868/915 MHz ELRS hardware cannot connect with 868/915 MHz mLRS hardware using the SX126x LoRa chipset (E5 Mini, E77 Easy Solder, E77 MBL). This is because the 868/915 MHz ELRS hardware uses the SX127x LoRa chipset, which is incompatible with the SX126x LoRa chipset for the spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the spreading factor which is used for the mLRS 31 Hz mode.
 
 ## Selected ELRS Receivers ##
 

--- a/docs/ELRS_RECEIVERS.md
+++ b/docs/ELRS_RECEIVERS.md
@@ -2,7 +2,7 @@
 
 ([back to main page](../README.md))
 
-Note: 868/915 MHz ELRS hardware cannot connect with 868/915 MHz mLRS hardware using the SX126x LoRa chipset (E5 Mini, E77 Easy Solder, E77 MBL). This is because the 868/915 MHz ELRS hardware uses the SX127x LoRa chipset, which is incompatible with the SX126x LoRa chipset for the spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the spreading factor which is used for the mLRS 31 Hz mode.
+Note: 868/915 MHz ELRS receivers are only compatible with the Frsky R9M Tx module.  868/915 MHz ELRS receivers are incompatible with SX126x hardware (SeeedStudio Wio-E5, EBYTE E77 MBL, E77 Easy Solder).
 
 ## Selected ELRS Receivers ##
 

--- a/docs/FRSKY_R9.md
+++ b/docs/FRSKY_R9.md
@@ -10,14 +10,6 @@ The Frsky R9M, R9M Lite Pro transmitter modules and R9 MX, R9 MM, R9 Mini receiv
       <td>Frequency Bands</td>
       <td>868 MHz/915 MHz</td>
     </tr>
-      <tr>
-      <td>LoRa Chipset</td>
-      <td>SX127x</td>
-    </tr>
-      <tr>
-      <td>Compatibility</td>
-      <td>Compatible with R9, ELRS Hardware.  Incompatible with E5 Mini, E77 Easy Solder, E77 MBL.</td>
-    </tr>
     <tr>
       <td>Max. RF Output Power</td>
       <td>30 dBm (1 W) for R9M, R9M Lite Pro, 17 dBm (50 mW) for R9 MX, R9 MM, R9 Mini</td>
@@ -25,6 +17,14 @@ The Frsky R9M, R9M Lite Pro transmitter modules and R9 MX, R9 MM, R9 Mini receiv
     <tr>
       <td>Supported Modes</td>
       <td>19 Hz</td>
+    </tr>
+    <tr>
+      <td>LoRa Chipset</td>
+      <td>SX127x</td>
+    </tr>
+      <tr>
+      <td>Compatibility</td>
+      <td>Compatible with Frsky R9 and ELRS hardware.  Incompatible with SX126x hardware (SeeedStudio Wio-E5, EBYTE E77 MBL, E77 Easy Solder).</td>
     </tr>
   </tbody>
 </table>

--- a/docs/FRSKY_R9.md
+++ b/docs/FRSKY_R9.md
@@ -2,6 +2,8 @@
 
 ([back to main page](../README.md))
 
+Note: 868/915 R9 hardware cannot connect with 868/915 MHz mLRS hardware using the SX126x LoRa chipset (E5 Mini, E77 Easy Solder, E77 MBL). This is because the 868/915 MHz R9 hardware uses the SX127x LoRa chipset, which is incompatible with the SX126x LoRa chipset for the spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the spreading factor which is used for the mLRS 31 Hz mode.
+
 The Frsky R9M, R9M Lite Pro transmitter modules and R9 MX, R9 MM, R9 Mini receivers can be a relatively easy way to get started with mLRS as they are commercially available. However, the R9 hardware does have some limitations as detailed below which may affect some applications.
 
 <table>
@@ -20,8 +22,6 @@ The Frsky R9M, R9M Lite Pro transmitter modules and R9 MX, R9 MM, R9 Mini receiv
     </tr>
   </tbody>
 </table>
-
-Note that R9 hardware cannot connect with mLRS boards which support 868/915 MHz and use the SX126x LoRa chipset. This is because R9 hardware uses the SX127x LoRa chipset, which is incompatible with the SF6 spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the SF5 spreading factor which is used for the mLRS 31 Hz mode.
 
 ## R9M Tx Module ##
 

--- a/docs/FRSKY_R9.md
+++ b/docs/FRSKY_R9.md
@@ -15,7 +15,7 @@ The Frsky R9M, R9M Lite Pro transmitter modules and R9 MX, R9 MM, R9 Mini receiv
       <td>SX127x</td>
     </tr>
       <tr>
-      <td>Compatability</td>
+      <td>Compatibility</td>
       <td>Compatible with R9, ELRS Hardware.  Incompatible with E5 Mini, E77 Easy Solder, E77 MBL.</td>
     </tr>
     <tr>

--- a/docs/FRSKY_R9.md
+++ b/docs/FRSKY_R9.md
@@ -2,8 +2,6 @@
 
 ([back to main page](../README.md))
 
-Note: 868/915 R9 hardware cannot connect with 868/915 MHz mLRS hardware using the SX126x LoRa chipset (E5 Mini, E77 Easy Solder, E77 MBL). This is because the 868/915 MHz R9 hardware uses the SX127x LoRa chipset, which is incompatible with the SX126x LoRa chipset for the spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the spreading factor which is used for the mLRS 31 Hz mode.
-
 The Frsky R9M, R9M Lite Pro transmitter modules and R9 MX, R9 MM, R9 Mini receivers can be a relatively easy way to get started with mLRS as they are commercially available. However, the R9 hardware does have some limitations as detailed below which may affect some applications.
 
 <table>
@@ -11,6 +9,14 @@ The Frsky R9M, R9M Lite Pro transmitter modules and R9 MX, R9 MM, R9 Mini receiv
     <tr>
       <td>Frequency Bands</td>
       <td>868 MHz/915 MHz</td>
+    </tr>
+      <tr>
+      <td>LoRa Chipset</td>
+      <td>SX127x</td>
+    </tr>
+      <tr>
+      <td>Compatability</td>
+      <td>Compatible with R9, ELRS Hardware.  Incompatible with E5 Mini, E77 Easy Solder, E77 MBL.</td>
     </tr>
     <tr>
       <td>Max. RF Output Power</td>

--- a/docs/SEEEDSTUDIO_WIO_E5.md
+++ b/docs/SEEEDSTUDIO_WIO_E5.md
@@ -21,6 +21,14 @@ The SeeedStudio [Wio-E5 module](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC
       <td>31 Hz, 19 Hz</td>
     </tr>
     <tr>
+      <td>LoRa Chipset</td>
+      <td>SX126x</td>
+    </tr>
+    <tr>
+      <td>Compatibility</td>
+      <td>Compatible with EBYTE E77 MBL, E77 Easy Solder.  Incompatible with SX127x hardware (Frsky R9 and ELRS).</td>
+    </tr>
+    <tr>
       <td>Weight</td>
       <td>Wio-E5 Mini: ~7 grams without antenna</td>
     </tr>

--- a/docs/SEEEDSTUDIO_WIO_E5.md
+++ b/docs/SEEEDSTUDIO_WIO_E5.md
@@ -2,6 +2,8 @@
 
 ([back to main page](../README.md))
 
+Note: 868/915 MHz E5 hardware cannot connect with 868/915 MHz mLRS hardware using the SX127x LoRa chipset (ELRS, R9). This is because the 868/915 MHz E5 hardware uses the SX126x LoRa chipset, which is incompatible with the SX127x LoRa chipset for the spreading factor used by the mLRS 19 Hz mode. In addition, the SX127x does not support the spreading factor which is used for the mLRS 31 Hz mode.
+
 The SeeedStudio [Wio-E5 module](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC_Module) is a highly attractive module for building mLRS equipment. SeeedStudio provides a number of boards which are based on this module, and which are quite interesting hardware for mLRS. However, these boards are not perfect since their pins are not ready-made for the purposes of mLRS. So, some tweaking and (easy) soldering is required.
 
 <table>


### PR DESCRIPTION
Note added to all 868/915 hardware pages stating that SX127x cannot be used with SX126x hardware.

To address: https://github.com/olliw42/mLRS-docu/issues/166