### PR TITLE
use MatekSys, streamline incompatibility notes, move FlySky one down

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Documentation for the [mLRS project](https://github.com/olliw42/mLRS).
 - [Experimental: Relay](docs/RELAY.md)
 
 ### STM32 Hardware ###
-- [Matek mLRS Hardware](docs/MATEKSYS.md)
-- [FlySky FRM303 Module](docs/FLYSKY_FRM303.md)
+- [MatekSys mLRS Hardware](docs/MATEKSYS.md)
 - [Frsky R9 Devices](docs/FRSKY_R9.md)
+- [FlySky FRM303 Module](docs/FLYSKY_FRM303.md)
 - [SeeedStudio Wio-E5 Boards](docs/SEEEDSTUDIO_WIO_E5.md)
 - [EBYTE E77 MBL Boards](docs/EBYTE_E77_MBL.md)
 - [E77 Easy Solder Boards](docs/E77_EASYSOLDER.md)

--- a/docs/E77_EASYSOLDER.md
+++ b/docs/E77_EASYSOLDER.md
@@ -24,7 +24,7 @@ The E77 Easy Solder Boards are designed to allow one with minimal soldering skil
     </tr>
       <tr>
       <td>Compatibility</td>
-      <td>Compatible with Matek mR900, SeeedStudio Wio-E5, EBYTE E77 MBL.  Incompatible with SX127x hardware (Frsky R9 and ELRS).</td>
+      <td>Compatible with MatekSys mR900, SeeedStudio Wio-E5, EBYTE E77 MBL. Incompatible with SX127x hardware (Frsky R9 and ELRS 900 MHz).</td>
     </tr>
   </tbody>
 </table>

--- a/docs/EBYTE_E77_MBL.md
+++ b/docs/EBYTE_E77_MBL.md
@@ -26,7 +26,7 @@ EBYTE E77 MBL Boards are an option for building mLRS equipment. These boards use
     </tr>
       <tr>
       <td>Compatibility</td>
-      <td>Compatible with SeeedStudio Wio-E5, E77 Easy Solder.  Incompatible with SX127x hardware (Frsky R9 and ELRS).</td>
+      <td>Compatible with MatekSys mR900, SeeedStudio Wio-E5, E77 Easy Solder. Incompatible with SX127x hardware (Frsky R9 and ELRS 900 MHz).</td>
     </tr>
     <tr>
       <td>Weight</td>

--- a/docs/ELRS_RECEIVERS.md
+++ b/docs/ELRS_RECEIVERS.md
@@ -2,7 +2,7 @@
 
 ([back to main page](../README.md))
 
-Note: 868/915 MHz ELRS receivers are only compatible with the Frsky R9M Tx module.  868/915 MHz ELRS receivers are incompatible with SX126x/STM32WLE hardware (Matek mR900, SeeedStudio Wio-E5, EBYTE E77 MBL, E77 Easy Solder).
+Note: 868/915 MHz ELRS receivers are only compatible with the Frsky R9M Tx module; they are incompatible with SX126x/STM32WLE hardware (MatekSys mR900, SeeedStudio Wio-E5, EBYTE E77 MBL, E77 Easy Solder)(see [here](SX126x_SX127x_INCOMPATIBILITY.md)).
 
 ## Selected ELRS Receivers ##
 

--- a/docs/FRSKY_R9.md
+++ b/docs/FRSKY_R9.md
@@ -24,7 +24,7 @@ The Frsky R9M, R9M Lite Pro transmitter modules and R9 MX, R9 MM, R9 Mini receiv
     </tr>
       <tr>
       <td>Compatibility</td>
-      <td>Compatible with Frsky R9 and ELRS hardware.  Incompatible with SX126x/STM32WLE hardware (Matek mR900, SeeedStudio Wio-E5, EBYTE E77 MBL, E77 Easy Solder).</td>
+      <td>Compatible with Frsky R9 and ELRS 900 MHz hardware. Incompatible with SX126x/STM32WLE hardware (MatekSys mR900, SeeedStudio Wio-E5, EBYTE E77 MBL, E77 Easy Solder).</td>
     </tr>
   </tbody>
 </table>

--- a/docs/MATEKSYS.md
+++ b/docs/MATEKSYS.md
@@ -6,9 +6,9 @@ The MatekSys mLRS Tx modules and receivers are specifically designed for mLRS an
 
 They are available for the 2.4 GHz band and the 868/915 MHz band. 
 
-Note: The MatekSys mLRS gear in the 868/915 MHz band use the newer SX126x chipset, and are incompatible with SX127x hardware (Frsky R9 system and ELRS 900 MHz gear).
+Note: The MatekSys mLRS gear in the 868/915 MHz band use the newer SX126x/STM32WLE chipset, and are incompatible with SX127x hardware (Frsky R9 system and ELRS 900 MHz gear)(see [here](SX126x_SX127x_INCOMPATIBILITY.md)).
 
-Links to the Matek website which include product specifications, instructions, etc. are found below:
+Links to the MatekSys website are found below, which include product specifications, excellent instructions, and more information:
 
 - [Product Page](https://www.mateksys.com/?page_id=12174)
 

--- a/docs/SEEEDSTUDIO_WIO_E5.md
+++ b/docs/SEEEDSTUDIO_WIO_E5.md
@@ -24,7 +24,7 @@ The SeeedStudio [Wio-E5 module](https://wiki.seeedstudio.com/LoRa-E5_STM32WLE5JC
     </tr>
     <tr>
       <td>Compatibility</td>
-      <td>Compatible with Matek mR900, EBYTE E77 MBL, E77 Easy Solder.  Incompatible with SX127x hardware (Frsky R9 and ELRS).</td>
+      <td>Compatible with MatekSys mR900, EBYTE E77 MBL, E77 Easy Solder. Incompatible with SX127x hardware (Frsky R9 and ELRS 900 MHz).</td>
     </tr>
     <tr>
       <td>Weight</td>


### PR DESCRIPTION
- change to MatekSys everywhere
- streamline incompatibility notes a bit
- on front page move FlySky one down