### PR TITLE
Avoid problem with MAVLink data confusing esp bootloader

### DIFF
--- a/docs/ELRS_RECEIVERS.md
+++ b/docs/ELRS_RECEIVERS.md
@@ -53,12 +53,18 @@ Note: In order to send RC channels over the serial connection, change the Rx Snd
     - GND to GND
     - Tx to Rx
     - Rx to Tx
-- When powering on the receiver you will need to have the bind button pushed down to enter into bootloader mode.
+- When powering on the receiver you will need to have the boot/bind button pushed down to enter into bootloader mode.
     - For receivers with a single (non-RGB) LED you can confirm the receiver is in bootloader mode if the LED is solid.
 - If you have already connected your receiver to your ArduPilot flight controller or if your ELRS receiver is built-in, you can use your flight controller with serial passthrough instead of an USB<>UART adapter.  This option requires ArduPilot version 4.5.2 or newer.
-    - Connect to your flight controller via USB using a MAVLink GCS on your PC and if you haven't already, set the correct SERIALx\_PROTOCOL parameter to 2 ("MAVLink2").  You may also want to set SERIALx\_BAUD at this time.
-	- Set SERIAL\_PASSTIMO to 0 to prevent timeout. SERIAL\_PASS1 should already be 0.
-	- Set SERIAL\_PASS2 to x, the serial port number your receiver is connected to.  Don't forget to write parameters if you are using Mission Planner or another GCS which requires this.  This step will start passthrough and cause the GCS to report connection lost.  Note that this parameter will revert to 0 and disable passthrough when you power cycle the FC after flashing.
+    - Connect to your flight controller via USB using a MAVLink GCS on your PC.
+	- Set SERIAL\_PASSTIMO to 0 to prevent timeout. Check SERIAL\_PASS1 which should already be 0.
+	- Set SERIALx_PROTOCOL to 28 ("Scripting") where x is the serial port number connected to your receiver.  This prevents MAVLink message traffic from confusing the bootloader before we enable passthrough below.  If you have scripts which use UART.write(), disable them.
+	- If you wish, you can set SERIALx_BAUD for use with mLRS/MAVLink at this time, though this setting does not matter while flashing.
+	- Power off both the flight controller and receiver (Unplug USB and power if connected)
+	- Power back up again while holding the boot/bind button down and confirm the LED is on solid.
+	- Connect your GCS again via USB.
+	- If you wish, you can set the SERIALx\_PROTOCOL parameter back to 2 ("MAVLink2") at this time so you don't need to set it after flashing.  But don't reboot or power cycle this time because we don't want it to take effect yet.
+	- Set SERIAL\_PASS2 to x, the serial port number your receiver is connected to.  Don't forget to write parameters if you are using Mission Planner or another GCS which requires this.  This step will start passthrough and cause the GCS to report communication lost.  Note that this parameter will revert to -1 and disable passthrough when you power cycle the FC after flashing.
 	- Exit the GCS program so the FC USB serial port is available for flashing.
 - Open a supported browser (Chrome, Edge, Opera, not Firefox) and navigate [here](https://esp.huhn.me/).
 - Click connect and select the serial port of your USB<>UART or FC.


### PR DESCRIPTION
set SERIALx_PROTOCOL to scripting before placing the radio in bootloader mode to avoid serial output before passthrough is enabled

