### PR TITLE
CRSF docs, some adjustments

### DIFF
--- a/docs/CRSF.md
+++ b/docs/CRSF.md
@@ -17,7 +17,7 @@ Optional but recommended steps:
 > [!TIP]
 > The mLRS default parameter settings follow the below recommendations. That is, with a freshly flashed mLRS Tx module and receiver all you need to do is to set up your radio and flight controller.
 
-It is recommeneded that for first setup the Tx module and receiver are left in their default configuration. Once your system is up and running there is still time to explore the options for optimizing the performacne.
+It is recommended for the initial setup the Tx module and receiver are left in their default configuration. Once your system is up and running then you can explore the options for further optimizing performance.
 
 ***Notes***:
 - Any radio which supports the CRSF protocol should work, this should include many brands besides EdgeTX/OpenTX radios.
@@ -46,7 +46,7 @@ Set the following parameters using the CLI or Lua script (or OLED if available):
 
 ***Notes***: 
 - Tx Ser Baudrate should be larger than the link data rate in order to provide enough capacity (e.g., in the 50 Hz mode the link data rate is 4100 Bytes/sec and the baudrate should thus be larger than 41000), but otherwise the choice is not critical and largely determined by the user's need. The default value is 115200, and is a good choice for most cases.
-- While not necessary, for the FLRC mode it can be benefitial to use 230400.
+- While not necessary, for the FLRC mode it can be beneficial to use 230400.
 
 ## ArduPilot Setup
 
@@ -60,7 +60,7 @@ A basic setup of the ArduPilot parameters is described in this section which sho
 
 ***Note***: 'x' refers to the serial port of your flight controller used for connecting with the mLRS receiver's serial port.
 
-The baud rate setting in SERIALx_BAUD is not critical, as mLRS will gracefully work with them all. However, depending on the ArduPilot firmware version, parameter download can be optimized somewhat by "tuning" the baudrate. For instance, one can try:
+The baud rate setting in SERIALx_BAUD is not critical, as mLRS will gracefully work with them all. However, for ArduPilot version 4.5 or lower, parameter download can be optimized somewhat by "tuning" the baudrate. For instance, one can try:
 - 50 Hz and FSK: 115 (= 115200)
 - 31 Hz: 57 (= 57600)
 - 19 Hz: 38 (= 38400)

--- a/docs/CRSF.md
+++ b/docs/CRSF.md
@@ -14,7 +14,10 @@ Optional but recommended steps:
 - Set the receiver into "MAVLink mode" (described below).
 - Install the Yaapu app (described below).
 
-The mLRS default parameter settings follow the below recommendations. That is, with a freshly flashed mLRS Tx module and receiver all you need to do is to set up your radio and flight controller!
+> [!TIP]
+> The mLRS default parameter settings follow the below recommendations. That is, with a freshly flashed mLRS Tx module and receiver all you need to do is to set up your radio and flight controller.
+
+It is recommeneded that for first setup the Tx module and receiver are left in their default configuration. Once your system is up and running there is still time to explore the options for optimizing the performacne.
 
 ***Notes***:
 - Any radio which supports the CRSF protocol should work, this should include many brands besides EdgeTX/OpenTX radios.
@@ -26,41 +29,43 @@ The mLRS default parameter settings follow the below recommendations. That is, w
 
 In EdgeTX/OpenTX, navigate to MDL->MODEL SETUP and configure the external RF module for CRSF protocol with 400K baud rate.
 
-***Note***: mLRS only supports 400K baud rate.
+> [!IMPORTANT]
+> mLRS only supports 400K baud rate.
 
 ## mLRS Tx Module Setup
 
 Set the following parameters using the CLI or Lua script (or OLED if available):
 
 - Tx Ch Source = crsf
-- Tx Ser Baudrate:
-    - 115200 for 19 Hz, 31 Hz, 50 Hz, FSK
-    - 230400 for FLRC (115200 also works)
+- Tx Ser Baudrate: 115200
 - Tx Ser Dest = serial or serial2 (not mbridge!)
 - Tx Snd RadioStat = on
 
-***Note***: Tx Ser Baudrate should be larger than the link data rate in order to provide enough capacity (e.g., in the 50 Hz mode the link data rate is 4100 Bytes/sec and the baudrate should thus be larger than 41000), but otherwise the choice is not critical and largely determined by the user's need. The default value is 115200, which is appropriate for all LoRa modes (50 Hz, 31 Hz, 19 Hz)(and also FSK).
+> [!TIP]
+> The mLRS default settings are Tx Ch Source = crsf, Tx Ser Baudrate = 115200, Tx Ser Dest = serial, Tx Snd RadioStat = on. Therefore, except of Tx Ser Dest, adjustment of the parameters is usually not needed.
 
-The mLRS default settings are Tx Ch Source = crsf, Tx Ser Baudrate = 115200, Tx Ser Dest = serial, Tx Snd RadioStat = on.
+***Notes***: 
+- Tx Ser Baudrate should be larger than the link data rate in order to provide enough capacity (e.g., in the 50 Hz mode the link data rate is 4100 Bytes/sec and the baudrate should thus be larger than 41000), but otherwise the choice is not critical and largely determined by the user's need. The default value is 115200, and is a good choice for most cases.
+- While not necessary, for the FLRC mode it can be benefitial to use 230400.
 
 ## ArduPilot Setup
 
-A basic setup is described in this section which should get one started, further ArduPilot information is available here: [ArduPilot Systems](ARDUPILOT.md).
+A basic setup of the ArduPilot parameters is described in this section which should get you started. Further ArduPilot information is available here: [ArduPilot Systems](ARDUPILOT.md).
 
 ### MAVLink Serial Port
 
-Generally, the baud rate setting is not critical, as mLRS will gracefully work with them all. However, parameter download depends somewhat on your ArduPilot firmware version.
-
-- SERIALx_BAUD:
-    - 115 (= 115200) for 50 Hz, FSK
-    - 57 (= 57600) for 31 Hz
-    - 38 (= 38400) for 19 Hz (57 works very well too, only parameter download is slower with ArduPilot 4.5)
-    - 230 (= 230400) for FLRC
+- SERIALx_BAUD: 57 (= 57600)
 - SERIALx_PROTOCOL = 2 (important, do not use MAVLink v1!)
 - SERIALx_OPTIONS = 4096 (ignore commands from GCS to change stream rates)
 
 ***Note***: 'x' refers to the serial port of your flight controller used for connecting with the mLRS receiver's serial port.
 
+The baud rate setting in SERIALx_BAUD is not critical, as mLRS will gracefully work with them all. However, depending on the ArduPilot firmware version, parameter download can be optimized somewhat by "tuning" the baudrate. For instance, one can try:
+- 50 Hz and FSK: 115 (= 115200)
+- 31 Hz: 57 (= 57600)
+- 19 Hz: 38 (= 38400)
+- FLRC: 230 (= 230400)
+ 
 ### Stream Rates
 
 Generally, the stream rate settings are not critical, as mLRS will gracefully adjust them when needed. Suggested settings are:
@@ -147,7 +152,7 @@ Generally, the stream rate settings are not critical, as mLRS will gracefully ad
   </tbody>
 </table>
 
-***Note***: When configuring SRy parameters, 'y' does not necessarily correspond to the number 'x' of the SERIALx port but to the count of serial ports using the MAVLink protocol.  SERIAL0, and thus SR0, will nearly always be reserved for the USB connection and set to use the MAVLink protocol (which should not be modified). Therefore, as an example, in a setup with SERIAL1 and SERIAL2 not set to the MAVLink and with the mLRS receiver connected to SERIAL3, then SR1 should be used to configured the stream rates for the mLRS receiver.
+***Note***: When configuring SRy parameters, 'y' does not necessarily correspond to the number 'x' of the SERIALx port but to the count of serial ports using the MAVLink protocol. SERIAL0, and thus SR0, will nearly always be reserved for the USB connection and set to use the MAVLink protocol (which should not be modified). Therefore, as an example, in a setup with SERIAL1 and SERIAL2 not set to the MAVLink and with the mLRS receiver connected to SERIAL3, then SR1 should be used to configured the stream rates for the mLRS receiver.
 
 ### CRSF Receiver Protocol
 
@@ -157,7 +162,7 @@ Generally, the stream rate settings are not critical, as mLRS will gracefully ad
 - SERIALx_OPTIONS = 0
 - SERIALx_PROTOCOL = 23
 
-***Note***: 'x' refers to the serial port of your flight controller used for CRSF.
+***Note***: 'x' refers to the serial port of your flight controller used for CRSF. This port is different (!) to the serial port used for the MAVLink serial stream.
 
 **If these settings do not work, more details are available on the [ArduPilot Systems](ARDUPILOT.md) page.**
 
@@ -170,8 +175,8 @@ Set the following parameters using the CLI or Lua script (or OLED if available):
 - Rx Ser Link Mode = mavlinkX (this sets the receiver into "MAVLink mode")
 - Rx Snd RadioStat= ardu_1
 
-The mLRS default settings are Rx Out Mode = crsf, Rx Ser Baudrate = 57600, Rx Ser Link Mode = mavlinkX, Rx Snd RadioStat= ardu_1.
-
+> [!TIP]
+> The mLRS default settings are Rx Out Mode = crsf, Rx Ser Baudrate = 57600, Rx Ser Link Mode = mavlinkX, Rx Snd RadioStat= ardu_1. Therefore, if the above suggestions are followed, the receiver should work out of the box.  
 
 ## Yaapu Telemetry App Setup for EdgeTX/OpenTX
 


### PR DESCRIPTION
some changes to the CRSF docs page
main purpose is to remove the various suggestions for teh baudrates, as mLRS shouls work with the defaults, and to rather move them to suggestion for optimization. 
Also the github tools for highlights is used, and some changes ehere and where in language.