### PR TITLE
compatibility chart: add examples of devices, show on main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Documentation for the [mLRS project](https://github.com/olliw42/mLRS).
 - [OLED Display](docs/OLED.md)
 - [Configuration ID](docs/CONFIGID.md)
 - [Flashing/Upgrading Firmware](docs/FLASHING.md)
+- [Compatibility Chart](docs/SX126x_SX127x_INCOMPATIBILITY.md)
 - [Logging](docs/LOGGING.md)
 - [Troubleshooting](docs/TROUBLE.md)
 

--- a/docs/SX126x_SX127x_INCOMPATIBILITY.md
+++ b/docs/SX126x_SX127x_INCOMPATIBILITY.md
@@ -15,6 +15,12 @@ Compatibility chart:
       <th>SX127x</th>
       <th colspan="2">LR1121</th>
     </tr><tr>
+      <td></td>
+      <td>MatekSys mR24, all ELRS 2400 gear, ...</td>
+      <td>MatekSys mR900, SeeedStudio Wio-E5, EBYTE E77 MBL, E77 Easy Solder, ...</td>
+      <td>Frsky R9M, all ELRS 900 gear, ...</td>
+      <td colspan="2">RM Nomad, GX12, TX15, XR4, ...</td>
+    </tr><tr>
       <th></th>
       <th><strong>2.4 GHz</strong></th>
       <th><strong>868/915 MHz</strong></th>


### PR DESCRIPTION
title says it
I guess it should be usefull to see xamples of devices for each chip
as well as being able to find teh chart from the main menu