### PR TITLE
main docs page, remove mTX, RP4TD links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Documentation for the [mLRS project](https://github.com/olliw42/mLRS).
 - [SBus Radios](docs/BASIC_SETUP.md)
 - [Additional Configuration for ArduPilot Systems](docs/ARDUPILOT.md)
 - [INAV/MSP Systems](docs/MSPX.md)
-- [mTX (formerly MAVLink for OpenTx)](docs/MTX.md)
 - [Experimental: Relay](docs/RELAY.md)
 
 ### STM32 Hardware ###
@@ -39,7 +38,6 @@ Documentation for the [mLRS project](https://github.com/olliw42/mLRS).
 ### ESP Hardware ###
 - [ELRS Receivers](docs/ELRS_RECEIVERS.md)
 - [ELRS Tx Modules](docs/ELRS_TX_MODULES.md)
-- [RadioMaster RP4TD](docs/ELRS_RADIOMASTER_RP4TD.md)
 - [ESP Development](docs/ESP_DEVELOPMENT.md)
 
 ### Advanced Options ###


### PR DESCRIPTION
let's see what you guys think of that
this PR removes the links to mTX and the RadioMaster RP4TD from the main page (only links, not docs itself)

mTX: 
well ... I think those few using it know how to use it ...

RP4TD: 
It somehow started to look displaced to me to have one device singled out. I think, if we wanted such a thing, we rather should create a new page with a couple rx devices which also could be used as tx module. The RP4TD would be just one. The downside of that is that we would have to offer the respective firmwares. IMHO, either we do that with some systematic, or not. 

I note that at least for one user using the RP4TD as tx has given serious issues, which we never resolved.